### PR TITLE
[전체 및 비교] 검색옵션 추가, 일용근로자 사유 및 스케줄러 구분

### DIFF
--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -28,6 +28,7 @@ type Worker struct {
 	CodeNm      null.String `json:"code_nm" db:"CODE_NM"`
 	IsUse       null.String `json:"is_use" db:"IS_USE"`
 	IsRetire    null.String `json:"is_retire" db:"IS_RETIRE"`
+	DailyReason null.String `json:"daily_reason" db:"DAILY_REASON"` // 일용근로자 사유
 	IsManage    null.String `json:"is_manage" db:"IS_MANAGE"`
 	RetireDate  null.Time   `json:"retire_date" db:"RETIRE_DATE"`
 	RecordDate  null.String `json:"record_date" db:"RECORD_DATE"`

--- a/csm-api/store/store_compare.go
+++ b/csm-api/store/store_compare.go
@@ -14,6 +14,8 @@ func (r *Repository) GetDailyWorkerList(ctx context.Context, db Queryer, compare
 	var columns []string
 	columns = append(columns, "T2.USER_NM")
 	columns = append(columns, "T2.DEPARTMENT")
+	columns = append(columns, "T2.USER_ID")
+	columns = append(columns, "T3.DEVICE_NM")
 	retryCondition := utils.RetrySearchTextConvert(retry, columns)
 
 	var orderBy string


### PR DESCRIPTION
1. [비교]: 검색 옵션에 USER_ID, DEVICE_NM 추가
2. [전체]: 일용근로자 사유 입력 추가
3. [스케줄러]: 관리자(협력사), 퇴사자 구분,  TRG_EDITABLE 'Y' OR IS NULL로 조건 수정